### PR TITLE
A11y/modals

### DIFF
--- a/src/DisclosureMenu.js
+++ b/src/DisclosureMenu.js
@@ -75,7 +75,7 @@ Garnish.DisclosureMenu = Garnish.Base.extend(
     focusElement: function(direction) {
       var currentFocus = $(':focus');
 
-      var focusable = this.$container.find(':focusable');
+      var focusable = Garnish.findFocusable(this.$container);
 
       var currentIndex = focusable.index(currentFocus);
       var newIndex;

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -26,6 +26,7 @@ Garnish = $.extend(Garnish, {
     // Key code constants
     DELETE_KEY: 8,
     SHIFT_KEY: 16,
+    TAB_KEY: 9,
     CTRL_KEY: 17,
     ALT_KEY: 18,
     RETURN_KEY: 13,

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -40,6 +40,11 @@ Garnish = $.extend(Garnish, {
     S_KEY: 83,
     CMD_KEY: 91,
 
+    // ARIA hidden classes
+    JS_ARIA_CLASS: 'garnish-js-aria',
+    JS_ARIA_TRUE_CLASS: 'garnish-js-aria-true',
+    JS_ARIA_FALSE_CLASS: 'garnish-js-aria-false',
+
     // Mouse button constants
     PRIMARY_CLICK: 1,
     SECONDARY_CLICK: 3,
@@ -216,6 +221,157 @@ Garnish = $.extend(Garnish, {
             wordSpacing: $source.css('wordSpacing'),
             wordWrap: $source.css('wordWrap')
         });
+    },
+
+    /**
+     * Adds modal ARIA and role attributes to a container
+     *
+     * @param {object} container The container element. Can be either an actual element or a jQuery collection.
+     */
+    addModalAttributes: function(container) {
+        var $container = $(container);
+
+        $(container).attr({
+            'aria-modal': 'true',
+            'role': 'dialog',
+        });
+    },
+
+    /**
+     * Hide immediate descendants of the body element from screen readers
+     *
+     * @param {object} modal The modal container. Can be either an actual element or a jQuery collection.
+     */
+    hideModalBackgroundContent: function(modal) {
+        var $modal = $(modal);
+
+        Garnish.$bod.children().each(function() {
+            // If element is modal or already has jsAria class, do nothing
+            if (Garnish.hasJsAriaClass(this) || this === $modal.get(0)) return;
+
+            if (Garnish.contentShouldBeHidden(this)) {
+                Garnish.ariaHide(this);
+            }
+        });
+    },
+
+    /**
+     * Un-hide elements underneath modal being closed
+     *
+     */
+    resetBackgroundContentVisibility: function() {
+        var $nextVisibleModal = Garnish.getNextVisibleModal();
+
+        // If there is another modal, make it accessible to AT
+        if ($nextVisibleModal) {
+            $nextVisibleModal.removeClass([Garnish.JS_ARIA_CLASS, Garnish.JS_ARIA_TRUE_CLASS, Garnish.JS_ARIA_FALSE_CLASS]);
+            $nextVisibleModal.removeAttr('aria-hidden');
+            return;
+        };
+
+        // If no more modals in DOM, loop through hidden elements and un-hide them
+        var ariaSelector = '.' + Garnish.JS_ARIA_CLASS + ', .' + Garnish.JS_ARIA_FALSE_CLASS + ', .' + Garnish.JS_ARIA_TRUE_CLASS;
+        var ariaHiddenElements = $(ariaSelector);
+
+        $(ariaHiddenElements).each(function() {
+            if ($(this).hasClass(Garnish.JS_ARIA_CLASS)) {
+                $(this).removeClass(Garnish.JS_ARIA_CLASS);
+                $(this).removeAttr('aria-hidden');
+            } else if ($(this).hasClass(Garnish.JS_ARIA_FALSE_CLASS)) {
+                $(this).removeClass(Garnish.JS_ARIA_FALSE_CLASS);
+                $(this).attr('aria-hidden', false);
+            } else if ($(this).hasClass(Garnish.JS_ARIA_TRUE_CLASS)) {
+                $(this).removeClass(Garnish.JS_ARIA_TRUE_CLASS);
+                $(this).attr('aria-hidden', true);
+            }
+        });
+    },
+
+    contentShouldBeHidden: function(element) {
+        var hide = true;
+        var tagName = $(element).prop('tagName');
+
+        // Do not hide script or style tags, or the visible modal container
+        if (tagName === 'SCRIPT' || tagName === 'STYLE') {
+            hide = false;
+        }
+
+        return hide;
+    },
+
+    /**
+     * Apply aria-hidden="true" to element and store previous value as class
+     *
+     * @param {object} element The element. Can be either an actual element or a jQuery collection.
+     */
+    ariaHide: function(element) {
+        var ariaHiddenAttribute = $(element).attr('aria-hidden');
+
+        // Capture initial aria-hidden values in an applied class
+        if (!ariaHiddenAttribute) {
+            $(element).addClass(Garnish.JS_ARIA_CLASS);
+        } else if (ariaHiddenAttribute === 'false') {
+            $(element).addClass(Garnish.JS_ARIA_FALSE_CLASS);
+        } else if (ariaHiddenAttribute === 'true') {
+            $(element.addClass(Garnish.JS_ARIA_TRUE_CLASS));
+        }
+
+        $(element).attr('aria-hidden', 'true');
+    },
+
+    getNextVisibleModal: function() {
+        var modals = $('[aria-modal="true"]').filter(function() {
+            return $(this).css('display') == 'block';
+        });
+
+        if (modals.length > 1) {
+            return modals[length - 1];
+        } else {
+            return null;
+        }
+    },
+
+    /**
+     * Has been hidden from screen reader users as a result of modal open
+     *
+     * @param {object} element The element. Can be either an actual element or a jQuery collection.
+     */
+    hasJsAriaClass: function(element) {
+        return $(element).hasClass(Garnish.JS_ARIA_CLASS) || $(element).hasClass(Garnish.JS_ARIA_FALSE_CLASS) || $(element).hasClass(Garnish.JS_ARIA_TRUE_CLASS);
+    },
+
+    /**
+     * Traps focus within a container, so when focus is tabbed out of it, it’s cycled back into it.
+     * @param {Object} container
+     */
+    trapFocusWithin: function(container) {
+        var $container = $(container);
+        $container.on('keydown.focus-trap', function (ev) {
+            // Tab key?
+            if (ev.keyCode === Garnish.TAB_KEY) {
+                var $focusableElements = $container.find(':focusable');
+                var index = $focusableElements.index(document.activeElement);
+                if (index !== -1) {
+                    if (index === 0 && ev.shiftKey) {
+                        ev.preventDefault();
+                        ev.stopPropagation();
+                        $focusableElements.last().focus();
+                    } else if (index === $focusableElements.length - 1 && !ev.shiftKey) {
+                        ev.psreventDefault();
+                        ev.stopPropagation();
+                        $focusableElements.first().focus();
+                    }
+                }
+            }
+        });
+    },
+
+    /**
+     * Sets focus to the first focusable element within a container.
+     * @param {Object} container
+     */
+    setFocusWithin: function(container) {
+        $(container).find(':focusable:first').focus();
     },
 
     /**

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -259,13 +259,13 @@ Garnish = $.extend(Garnish, {
      * Un-hide elements underneath modal being closed
      *
      */
-    resetBackgroundContentVisibility: function() {
-        var $nextVisibleModal = Garnish.getNextVisibleModal();
+    resetBackgroundContentVisibility: function(container) {
+        var nextVisibleModal = Garnish.getNextVisibleModal(container);
 
         // If there is another modal, make it accessible to AT
-        if ($nextVisibleModal) {
-            $nextVisibleModal.removeClass([Garnish.JS_ARIA_CLASS, Garnish.JS_ARIA_TRUE_CLASS, Garnish.JS_ARIA_FALSE_CLASS]);
-            $nextVisibleModal.removeAttr('aria-hidden');
+        if (nextVisibleModal) {
+            $(nextVisibleModal).removeClass([Garnish.JS_ARIA_CLASS, Garnish.JS_ARIA_TRUE_CLASS, Garnish.JS_ARIA_FALSE_CLASS]);
+            $(nextVisibleModal).removeAttr('aria-hidden');
             return;
         };
 
@@ -319,13 +319,16 @@ Garnish = $.extend(Garnish, {
         $(element).attr('aria-hidden', 'true');
     },
 
-    getNextVisibleModal: function() {
+    getNextVisibleModal: function(container) {
         var modals = $('[aria-modal="true"]').filter(function() {
             return $(this).css('display') == 'block';
         });
 
-        if (modals.length > 1) {
-            return modals[length - 1];
+        var prevContainerIndex = $(modals).index(container);
+        var newModals = $(modals).slice(0, prevContainerIndex);
+
+        if (newModals.length) {
+            return $(newModals).last();
         } else {
             return null;
         }
@@ -347,20 +350,20 @@ Garnish = $.extend(Garnish, {
     trapFocusWithin: function(container) {
         var $container = $(container);
         $container.on('keydown.focus-trap', function (ev) {
-            // Tab key?
             if (ev.keyCode === Garnish.TAB_KEY) {
                 var $focusableElements = $container.find(':focusable');
-                var index = $focusableElements.index(document.activeElement);
-                if (index !== -1) {
-                    if (index === 0 && ev.shiftKey) {
-                        ev.preventDefault();
-                        ev.stopPropagation();
-                        $focusableElements.last().focus();
-                    } else if (index === $focusableElements.length - 1 && !ev.shiftKey) {
-                        ev.psreventDefault();
-                        ev.stopPropagation();
-                        $focusableElements.first().focus();
-                    }
+                var index = $focusableElements.index(ev.target);
+
+                if (index === 0 && ev.shiftKey) {
+                    console.log('tab shift');
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    $focusableElements.last().focus();
+                } else if (index === $focusableElements.length - 1 && !ev.shiftKey) {
+                    console.log('tab press');
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    $focusableElements.first().focus();
                 }
             }
         });

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -451,6 +451,15 @@ Garnish = $.extend(Garnish, {
     },
 
     /**
+     * Returns the currently focused element
+     *
+     * @return {object}
+     */
+    findCurrentFocus: function() {
+        return $(':focus');
+    },
+
+    /**
      * Returns the post data within a container.
      *
      * @param {object} container

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -355,12 +355,10 @@ Garnish = $.extend(Garnish, {
                 var index = $focusableElements.index(ev.target);
 
                 if (index === 0 && ev.shiftKey) {
-                    console.log('tab shift');
                     ev.preventDefault();
                     ev.stopPropagation();
                     $focusableElements.last().focus();
                 } else if (index === $focusableElements.length - 1 && !ev.shiftKey) {
-                    console.log('tab press');
                     ev.preventDefault();
                     ev.stopPropagation();
                     $focusableElements.first().focus();

--- a/src/Garnish.js
+++ b/src/Garnish.js
@@ -441,6 +441,16 @@ Garnish = $.extend(Garnish, {
     },
 
     /**
+     * Returns the focusable elements within a container
+     *
+     * @param {object} container The container element. Can be either an actual element or a jQuery collection.
+     * @return {object}
+     */
+    findFocusable: function(container) {
+        return $(container).find(':focusable');
+    },
+
+    /**
      * Returns the post data within a container.
      *
      * @param {object} container

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -98,6 +98,9 @@ Garnish.Modal = Garnish.Base.extend(
             var modal = this;
 
             Garnish.$bod.children().each(function() {
+                // If element already has jsAria class, do nothing
+                if (modal.hasJsAriaClass(this)) return;
+
                 if (modal.contentShouldBeHidden(this)) {
                     modal.ariaHide(this);
                 }
@@ -125,6 +128,10 @@ Garnish.Modal = Garnish.Base.extend(
             });
         },
 
+        hasJsAriaClass: function(element) {
+            return $(element).hasClass(this.settings.jsAriaClass) || $(element).hasClass(this.settings.jsAriaFalseClass) || $(element).hasClass(this.settings.jsAriaTrueClass);
+        },
+
         ariaHide: function(element) {
             var ariaHiddenAttribute = $(element).attr('aria-hidden');
 
@@ -144,6 +151,7 @@ Garnish.Modal = Garnish.Base.extend(
             var hide = true;
             var tagName = $(element).prop('tagName');
 
+            // Do not hide script or style tags, or the visible modal container
             if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === Garnish.Modal.visibleModal.$container.get(0)) {
                 hide = false;
             }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -39,6 +39,7 @@ Garnish.Modal = Garnish.Base.extend(
             }
 
             if (container) {
+                this.addAriaAttributes(container);
                 this.setContainer(container);
 
                 if (this.settings.autoShow) {
@@ -49,11 +50,8 @@ Garnish.Modal = Garnish.Base.extend(
             Garnish.Modal.instances.push(this);
         },
 
-        addAriaAttributes: function() {
-
-            if (!this.$container) return;
-            console.log(this.$container);
-            this.$container.attr({
+        addAriaAttributes: function(container) {
+            $(container).attr({
                 'aria-modal': 'true',
                 'role': 'dialog',
             });
@@ -95,6 +93,39 @@ Garnish.Modal = Garnish.Base.extend(
             }
         },
 
+        hideOutsideContent: function() {
+            // Hide body content from screen reader users
+            var modal = this;
+            Garnish.$bod.children().each(function() {
+                if (modal.contentShouldBeHidden(this)) {
+                    modal.setAriaClass(this);
+                }
+            });
+        },
+
+        setAriaClass: function(element) {
+            var ariaHiddenAttribute = $(element).attr('aria-hidden');
+
+            if (ariaHiddenAttribute === 'true') {
+                $(element).addClass(this.settings.jsAriaTrueClass);
+            } else if (ariaHiddenAttribute === 'false') {
+                $(element).addClass(this.settings.jsAriaFalseClass);
+            } else {
+                $(element.addClass(this.settings.jsAriaClass));
+            }
+        },
+
+        contentShouldBeHidden: function(element) {
+            var hide = true;
+            var tagName = $(element).prop('tagName');
+
+            if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === this.$container.get(0)) {
+                hide = false;
+            }
+
+            return hide;
+        },
+
         show: function() {
             // Close other modals as needed
             if (this.settings.closeOtherModals && Garnish.Modal.visibleModal && Garnish.Modal.visibleModal !== this) {
@@ -120,6 +151,8 @@ Garnish.Modal = Garnish.Base.extend(
                         });
                     }.bind(this)
                 });
+
+                this.hideOutsideContent();
 
                 if (this.settings.hideOnShadeClick) {
                     this.addListener(this.$shade, 'click', 'hide');
@@ -346,7 +379,10 @@ Garnish.Modal = Garnish.Base.extend(
             closeOtherModals: false,
             hideOnEsc: true,
             hideOnShadeClick: true,
-            shadeClass: 'modal-shade'
+            shadeClass: 'modal-shade',
+            jsAriaClass: 'garnish-js-aria',
+            jsAriaTrueClass: 'garnish-js-aria-true',
+            jsAriaFalseClass: 'garnish-js-aria-false',
         },
         instances: [],
         visibleModal: null

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -181,6 +181,9 @@ Garnish.Modal = Garnish.Base.extend(
                     this.addListener(this.$shade, 'click', 'hide');
                 }
 
+                // Add focus trap listeners
+                this.addListener(this.$container, 'keydown', 'handleKeydown');
+
                 this.addListener(Garnish.$win, 'resize', '_handleWindowResize');
             }
 
@@ -201,6 +204,29 @@ Garnish.Modal = Garnish.Base.extend(
             }
 
             this.hideOutsideContent();
+        },
+
+        getFocusableElements: function() {
+            return this.$container.find(':focusable');
+        },
+
+        handleKeydown: function(event) {
+            if (event.keyCode !== Garnish.TAB_KEY) return;
+
+            var focusable = this.getFocusableElements();
+            var target = $(event.target);
+
+            if (event.shiftKey) { // Handle reverse TAB by looping to beginning of container
+                if (target.is(focusable.first())) {
+                    focusable.last().focus();
+                    event.preventDefault();
+                }
+            } else {
+                if (target.is(focusable.last())) {
+                    focusable.first().focus();
+                    event.preventDefault();
+                }
+            }
         },
 
         quickShow: function() {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,6 +6,7 @@ Garnish.Modal = Garnish.Base.extend(
     {
         $container: null,
         $shade: null,
+        $trigger: null,
 
         visible: false,
 
@@ -29,6 +30,12 @@ Garnish.Modal = Garnish.Base.extend(
 
             // Create the shade
             this.$shade = $('<div class="' + this.settings.shadeClass + '"/>');
+
+            // Store trigger
+            var trigger = Garnish.findCurrentFocus();
+            if (trigger) {
+                this.$trigger = trigger;
+            }
 
             // If the container is already set, drop the shade below it.
             if (container) {
@@ -264,6 +271,10 @@ Garnish.Modal = Garnish.Base.extend(
                 this.removeListener(this.$container, 'keydown', 'handleKeydown');
 
                 this.removeListener(Garnish.$win, 'resize');
+            }
+
+            if (this.$trigger) {
+                this.$trigger.focus();
             }
 
             this.visible = false;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -96,30 +96,55 @@ Garnish.Modal = Garnish.Base.extend(
         hideOutsideContent: function() {
             // Hide body content from screen reader users
             var modal = this;
+
             Garnish.$bod.children().each(function() {
                 if (modal.contentShouldBeHidden(this)) {
-                    modal.setAriaClass(this);
+                    modal.ariaHide(this);
                 }
             });
         },
 
-        setAriaClass: function(element) {
+        resetOutsideContentVisibility: function() {
+            var ariaSelector = '.' + this.settings.jsAriaClass + ', .' + this.settings.jsAriaFalseClass + ', .' + this.settings.jsAriaTrueClass;
+
+            var ariaHiddenElements = $(ariaSelector);
+            var modal = this;
+
+            // Go through each and restore to initial value
+            $(ariaHiddenElements).each(function() {
+                if ($(this).hasClass(modal.settings.jsAriaClass)) {
+                    $(this).removeClass(modal.settings.jsAriaClass);
+                    $(this).removeAttr('aria-hidden');
+                } else if ($(this).hasClass(modal.settings.jsAriaFalseClass)) {
+                    $(this).removeClass(modal.settings.jsAriaFalseClass);
+                    $(this).attr('aria-hidden', false);
+                } else if ($(this).hasClass(modal.settings.jsAriaTrueClass)) {
+                    $(this).removeClass(modal.settings.jsAriaTrueClass);
+                    $(this).attr('aria-hidden', true);
+                }
+            });
+        },
+
+        ariaHide: function(element) {
             var ariaHiddenAttribute = $(element).attr('aria-hidden');
 
-            if (ariaHiddenAttribute === 'true') {
-                $(element).addClass(this.settings.jsAriaTrueClass);
+            // Capture initial aria-hidden values in an applied class
+            if (!ariaHiddenAttribute) {
+                $(element).addClass(this.settings.jsAriaClass);
             } else if (ariaHiddenAttribute === 'false') {
                 $(element).addClass(this.settings.jsAriaFalseClass);
-            } else {
-                $(element.addClass(this.settings.jsAriaClass));
+            } else if (ariaHiddenAttribute === 'true') {
+                $(element.addClass(this.settings.jsAriaTrueClass));
             }
+
+            $(element).attr('aria-hidden', 'true');
         },
 
         contentShouldBeHidden: function(element) {
             var hide = true;
             var tagName = $(element).prop('tagName');
 
-            if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === this.$container.get(0)) {
+            if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === Garnish.Modal.visibleModal.$container.get(0)) {
                 hide = false;
             }
 
@@ -152,8 +177,6 @@ Garnish.Modal = Garnish.Base.extend(
                     }.bind(this)
                 });
 
-                this.hideOutsideContent();
-
                 if (this.settings.hideOnShadeClick) {
                     this.addListener(this.$shade, 'click', 'hide');
                 }
@@ -176,6 +199,8 @@ Garnish.Modal = Garnish.Base.extend(
                 this.trigger('show');
                 this.settings.onShow();
             }
+
+            this.hideOutsideContent();
         },
 
         quickShow: function() {
@@ -219,6 +244,7 @@ Garnish.Modal = Garnish.Base.extend(
             Garnish.Modal.visibleModal = null;
             Garnish.shortcutManager.removeLayer();
             this.trigger('hide');
+            this.resetOutsideContentVisibility();
             this.settings.onHide();
         },
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -135,11 +135,11 @@ Garnish.Modal = Garnish.Base.extend(
                     Garnish.shortcutManager.registerShortcut(Garnish.ESC_KEY, this.hide.bind(this));
                 }
 
+                Garnish.hideModalBackgroundContent(this.$container);
+
                 this.trigger('show');
                 this.settings.onShow();
             }
-
-            Garnish.hideModalBackgroundContent(this.$container);
         },
 
         quickShow: function() {
@@ -187,7 +187,7 @@ Garnish.Modal = Garnish.Base.extend(
             Garnish.Modal.visibleModal = null;
             Garnish.shortcutManager.removeLayer();
             this.trigger('hide');
-            Garnish.resetBackgroundContentVisibility();
+            Garnish.resetBackgroundContentVisibility(this.$container);
             this.settings.onHide();
         },
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,7 +6,7 @@ Garnish.Modal = Garnish.Base.extend(
     {
         $container: null,
         $shade: null,
-        $trigger: null,
+        $triggerElement: null,
 
         visible: false,
 
@@ -31,10 +31,9 @@ Garnish.Modal = Garnish.Base.extend(
             // Create the shade
             this.$shade = $('<div class="' + this.settings.shadeClass + '"/>');
 
-            // Store trigger
-            var trigger = Garnish.findCurrentFocus();
-            if (trigger) {
-                this.$trigger = trigger;
+            // Store triggering element
+            if (Garnish.findCurrentFocus()) {
+                this.$triggerElement = Garnish.findCurrentFocus();
             }
 
             // If the container is already set, drop the shade below it.
@@ -165,6 +164,10 @@ Garnish.Modal = Garnish.Base.extend(
                 Garnish.Modal.visibleModal.hide();
             }
 
+            if (Garnish.findCurrentFocus() !== this.$triggerElement) {
+                this.$triggerElement = Garnish.findCurrentFocus();
+            }
+
             if (this.$container) {
                 // Move it to the end of <body> so it gets the highest sub-z-index
                 this.$shade.appendTo(Garnish.$bod);
@@ -273,8 +276,8 @@ Garnish.Modal = Garnish.Base.extend(
                 this.removeListener(Garnish.$win, 'resize');
             }
 
-            if (this.$trigger) {
-                this.$trigger.focus();
+            if (this.$triggerElement) {
+                this.$triggerElement.focus();
             }
 
             this.visible = false;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -144,6 +144,7 @@ Garnish.Modal = Garnish.Base.extend(
             var hide = true;
             var tagName = $(element).prop('tagName');
 
+            // TODO clean up this conditional
             if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === Garnish.Modal.visibleModal.$container.get(0)) {
                 hide = false;
             }
@@ -181,7 +182,7 @@ Garnish.Modal = Garnish.Base.extend(
                     this.addListener(this.$shade, 'click', 'hide');
                 }
 
-                // Add focus trap listeners
+                // Add keydown listener for focus trap
                 this.addListener(this.$container, 'keydown', 'handleKeydown');
 
                 this.addListener(Garnish.$win, 'resize', '_handleWindowResize');
@@ -206,14 +207,10 @@ Garnish.Modal = Garnish.Base.extend(
             this.hideOutsideContent();
         },
 
-        getFocusableElements: function() {
-            return this.$container.find(':focusable');
-        },
-
         handleKeydown: function(event) {
             if (event.keyCode !== Garnish.TAB_KEY) return;
 
-            var focusable = this.getFocusableElements();
+            var focusable = Garnish.findFocusable(this.$container);
             var target = $(event.target);
 
             if (event.shiftKey) { // Handle reverse TAB by looping to beginning of container
@@ -262,6 +259,9 @@ Garnish.Modal = Garnish.Base.extend(
                 if (this.settings.hideOnShadeClick) {
                     this.removeListener(this.$shade, 'click');
                 }
+
+                // Remove keydown listener for focus trap
+                this.removeListener(this.$container, 'keydown', 'handleKeydown');
 
                 this.removeListener(Garnish.$win, 'resize');
             }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -49,6 +49,16 @@ Garnish.Modal = Garnish.Base.extend(
             Garnish.Modal.instances.push(this);
         },
 
+        addAriaAttributes: function() {
+
+            if (!this.$container) return;
+            console.log(this.$container);
+            this.$container.attr({
+                'aria-modal': 'true',
+                'role': 'dialog',
+            });
+        },
+
         setContainer: function(container) {
             this.$container = $(container);
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,7 +6,6 @@ Garnish.Modal = Garnish.Base.extend(
     {
         $container: null,
         $shade: null,
-        $triggerElement: null,
 
         visible: false,
 
@@ -30,11 +29,6 @@ Garnish.Modal = Garnish.Base.extend(
 
             // Create the shade
             this.$shade = $('<div class="' + this.settings.shadeClass + '"/>');
-
-            // Store triggering element
-            if (Garnish.findCurrentFocus()) {
-                this.$triggerElement = Garnish.findCurrentFocus();
-            }
 
             // If the container is already set, drop the shade below it.
             if (container) {
@@ -164,10 +158,6 @@ Garnish.Modal = Garnish.Base.extend(
                 Garnish.Modal.visibleModal.hide();
             }
 
-            if (Garnish.findCurrentFocus() !== this.$triggerElement) {
-                this.$triggerElement = Garnish.findCurrentFocus();
-            }
-
             if (this.$container) {
                 // Move it to the end of <body> so it gets the highest sub-z-index
                 this.$shade.appendTo(Garnish.$bod);
@@ -276,8 +266,8 @@ Garnish.Modal = Garnish.Base.extend(
                 this.removeListener(Garnish.$win, 'resize');
             }
 
-            if (this.$triggerElement) {
-                this.$triggerElement.focus();
+            if (this.settings.triggerElement) {
+                this.settings.triggerElement.focus();
             }
 
             this.visible = false;
@@ -445,6 +435,7 @@ Garnish.Modal = Garnish.Base.extend(
             closeOtherModals: false,
             hideOnEsc: true,
             hideOnShadeClick: true,
+            triggerElement: null,
             shadeClass: 'modal-shade',
             jsAriaClass: 'garnish-js-aria',
             jsAriaTrueClass: 'garnish-js-aria-true',

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -144,7 +144,6 @@ Garnish.Modal = Garnish.Base.extend(
             var hide = true;
             var tagName = $(element).prop('tagName');
 
-            // TODO clean up this conditional
             if (tagName === 'SCRIPT' || tagName === 'STYLE' || element === Garnish.Modal.visibleModal.$container.get(0)) {
                 hide = false;
             }
@@ -172,6 +171,7 @@ Garnish.Modal = Garnish.Base.extend(
                         this.$container.velocity('fadeIn', {
                             complete: function() {
                                 this.updateSizeAndPosition();
+                                this.moveFocusInto();
                                 this.onFadeIn();
                             }.bind(this)
                         });
@@ -205,6 +205,14 @@ Garnish.Modal = Garnish.Base.extend(
             }
 
             this.hideOutsideContent();
+        },
+
+        moveFocusInto: function() {
+            var focusable = Garnish.findFocusable(this.$container);
+
+            if (!focusable.length) return;
+
+            focusable.first().focus();
         },
 
         handleKeydown: function(event) {


### PR DESCRIPTION
### Description
Aims to fix a few accessibility issues with modals, including the following:

- Activating a focus trap on the modal
- Setting `aria-hidden="true"` on all sibling elements in the body (not including `style` or `script` tags)
- Add `triggerElement` setting to store default element to refocus on close

This is being worked on consecutively with updates in the CMS repo

### Related issues
CMS-009, CMS-010, and CMS-014 in issue tracker